### PR TITLE
Add capability to understand mysql INSERT IGNORE statements

### DIFF
--- a/lib/my_obfuscate/insert_statement_parser.rb
+++ b/lib/my_obfuscate/insert_statement_parser.rb
@@ -6,8 +6,9 @@ class MyObfuscate
         if table_data = parse_insert_statement(line)
           table_name = table_data[:table_name]
           columns = table_data[:column_names]
+          ignore = table_data[:ignore]
           if config[table_name]
-            output_io.puts obfuscator.obfuscate_bulk_insert_line(line, table_name, columns)
+            output_io.puts obfuscator.obfuscate_bulk_insert_line(line, table_name, columns, ignore)
           else
             $stderr.puts "Deprecated: #{table_name} was not specified in the config.  A future release will cause this to be an error.  Please specify the table definition or set it to :keep."
             output_io.write line
@@ -20,3 +21,5 @@ class MyObfuscate
 
   end
 end
+
+

--- a/lib/my_obfuscate/mysql.rb
+++ b/lib/my_obfuscate/mysql.rb
@@ -5,7 +5,7 @@ class MyObfuscate
     def parse_insert_statement(line)
       if regex_match = insert_regex.match(line)
         {
-            :ignore     => regex_match[1],
+            :ignore     => !regex_match[1].nil?,
             :table_name => regex_match[2].to_sym,
             :column_names => regex_match[3].split(/`\s*,\s*`/).map { |col| col.gsub('`', "").to_sym }
         }
@@ -17,7 +17,7 @@ class MyObfuscate
         "(" + values.join(",") + ")"
       end.join(",")
 
-      "INSERT #{ignore}INTO `#{table_name}` (`#{column_names.join('`, `')}`) VALUES #{values_strings};"
+      "INSERT #{ignore ? 'IGNORE ' : '' }INTO `#{table_name}` (`#{column_names.join('`, `')}`) VALUES #{values_strings};"
     end
 
     def insert_regex

--- a/lib/my_obfuscate/mysql.rb
+++ b/lib/my_obfuscate/mysql.rb
@@ -5,22 +5,23 @@ class MyObfuscate
     def parse_insert_statement(line)
       if regex_match = insert_regex.match(line)
         {
-            :table_name => regex_match[1].to_sym,
-            :column_names => regex_match[2].split(/`\s*,\s*`/).map { |col| col.gsub('`', "").to_sym }
+            :ignore     => regex_match[1],
+            :table_name => regex_match[2].to_sym,
+            :column_names => regex_match[3].split(/`\s*,\s*`/).map { |col| col.gsub('`', "").to_sym }
         }
       end
     end
 
-    def make_insert_statement(table_name, column_names, values)
+    def make_insert_statement(table_name, column_names, values, ignore = nil)
       values_strings = values.collect do |values|
         "(" + values.join(",") + ")"
       end.join(",")
 
-      "INSERT INTO `#{table_name}` (`#{column_names.join('`, `')}`) VALUES #{values_strings};"
+      "INSERT #{ignore}INTO `#{table_name}` (`#{column_names.join('`, `')}`) VALUES #{values_strings};"
     end
 
     def insert_regex
-      /^\s*INSERT INTO `(.*?)` \((.*?)\) VALUES\s*/i
+      /^\s*INSERT\s*(IGNORE )?\s*INTO `(.*?)` \((.*?)\) VALUES\s*/i
     end
 
     def rows_to_be_inserted(line)

--- a/lib/my_obfuscate/postgres.rb
+++ b/lib/my_obfuscate/postgres.rb
@@ -2,7 +2,7 @@ class MyObfuscate
   class Postgres
     include MyObfuscate::CopyStatementParser
 
-    # Copy statements contain the column values tab seperated like so:
+    # Copy statements contain the column values tab separated like so:
     #   blah	blah	blah	blah
     # which we want to turn into:
     #   [['blah','blah','blah','blah']]
@@ -33,7 +33,7 @@ class MyObfuscate
       end
     end
 
-    def make_insert_statement(table_name, column_names, values)
+    def make_insert_statement(table_name, column_names, values, ignore = nil)
       values.join("\t")
     end
 

--- a/lib/my_obfuscate/sql_server.rb
+++ b/lib/my_obfuscate/sql_server.rb
@@ -26,7 +26,7 @@ class MyObfuscate
       end
     end
 
-    def make_insert_statement(table_name, column_names, values)
+    def make_insert_statement(table_name, column_names, values, ignore = nil)
       values_strings = values.collect do |values|
         "(" + values.join(",") + ")"
       end.join(",")

--- a/spec/my_obfuscate/mysql_spec.rb
+++ b/spec/my_obfuscate/mysql_spec.rb
@@ -73,7 +73,14 @@ describe MyObfuscate::Mysql do
 
     it "should return a hash of table name, column names for MySQL insert statements" do
       hash = subject.parse_insert_statement("INSERT INTO `some_table` (`email`, `name`, `something`, `age`) VALUES ('bob@honk.com','bob', 'some\\'thin,ge())lse1', 25),('joe@joe.com','joe', 'somethingelse2', 54);")
-      expect(hash).to eq({:table_name => :some_table, :column_names => [:email, :name, :something, :age]})
+      expect(hash).to eq({:ignore => nil, :table_name => :some_table, :column_names => [:email, :name, :something, :age]})
+    end
+  end
+
+  describe "#parse_insert_ignore_statement" do
+    it "should return a hash of IGNORE, table name, column names for MySQL insert statements" do
+      hash = subject.parse_insert_statement("INSERT IGNORE INTO `some_table` (`email`, `name`, `something`, `age`) VALUES ('bob@honk.com','bob', 'some\\'thin,ge())lse1', 25),('joe@joe.com','joe', 'somethingelse2', 54);")
+      expect(hash).to eq({:ignore => "IGNORE ", :table_name => :some_table, :column_names => [:email, :name, :something, :age]})
     end
   end
 

--- a/spec/my_obfuscate/mysql_spec.rb
+++ b/spec/my_obfuscate/mysql_spec.rb
@@ -73,14 +73,14 @@ describe MyObfuscate::Mysql do
 
     it "should return a hash of table name, column names for MySQL insert statements" do
       hash = subject.parse_insert_statement("INSERT INTO `some_table` (`email`, `name`, `something`, `age`) VALUES ('bob@honk.com','bob', 'some\\'thin,ge())lse1', 25),('joe@joe.com','joe', 'somethingelse2', 54);")
-      expect(hash).to eq({:ignore => nil, :table_name => :some_table, :column_names => [:email, :name, :something, :age]})
+      expect(hash).to eq({:ignore => false, :table_name => :some_table, :column_names => [:email, :name, :something, :age]})
     end
   end
 
   describe "#parse_insert_ignore_statement" do
     it "should return a hash of IGNORE, table name, column names for MySQL insert statements" do
       hash = subject.parse_insert_statement("INSERT IGNORE INTO `some_table` (`email`, `name`, `something`, `age`) VALUES ('bob@honk.com','bob', 'some\\'thin,ge())lse1', 25),('joe@joe.com','joe', 'somethingelse2', 54);")
-      expect(hash).to eq({:ignore => "IGNORE ", :table_name => :some_table, :column_names => [:email, :name, :something, :age]})
+      expect(hash).to eq({:ignore => true, :table_name => :some_table, :column_names => [:email, :name, :something, :age]})
     end
   end
 


### PR DESCRIPTION
In our workflow we have need for mysqldump `--insert-ignore` option, which creates `INSERT IGNORE` statements rather than plain `INSERT` statements.  This small modification permits for either `INSERT` or `INSERT IGNORE` on input and passes the same to output.  

Should have no effect on postgres or sql server.